### PR TITLE
Remove ** from file names and remove ' from commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,33 +22,33 @@ For more information on making a Weight & Biases account see [(creating a weight
 
 ## Running an experiment
 To rerun the experiment from Figure 3, you can run:
-- `tvae --name 'tvae_2d_mnist'`
+- `tvae --name tvae_2d_mnist`
 
 To rerun the experiments from Figure 4, you can run:
-- `tvae --name 'tvae_Lpartial_mnist'`
-- `tvae --name 'tvae_Lpartial_dsprites'`
+- `tvae --name tvae_Lpartial_mnist`
+- `tvae --name tvae_Lpartial_dsprites`
 
 To rerun the experiments from Tables 1, you can run:
-- `tvae --name 'tvae_Lhalf_mnist'`
-- `tvae --name 'tvae_Lshort_mnist'`
-- `tvae --name 'bubbles_mnist'`
-- `tvae --name 'tvae_L0_mnist'`
-- `tvae --name 'nontvae_mnist'`
+- `tvae --name tvae_Lhalf_mnist`
+- `tvae --name tvae_Lshort_mnist`
+- `tvae --name bubbles_mnist`
+- `tvae --name tvae_L0_mnist`
+- `tvae --name nontvae_mnist`
 
 To rerun the experiments from Tables 2, you can run:
-- `tvae --name 'tvae_Lhalf_dsprites'`
-- `tvae --name 'tvae_Lpartial_dsprites'`
-- `tvae --name 'tvae_Lshort_dsprites'`
-- `tvae --name 'bubbles_dsprites'`
-- `tvae --name 'tvae_L0_dsprites'`
-- `tvae --name 'nontvae_dsprites'`
+- `tvae --name tvae_Lhalf_dsprites`
+- `tvae --name tvae_Lpartial_dsprites`
+- `tvae --name tvae_Lshort_dsprites`
+- `tvae --name bubbles_dsprites`
+- `tvae --name tvae_L0_dsprites`
+- `tvae --name nontvae_dsprites`
 
 To rerun the generalization experiment described in Section B.4 (resulting in Figures 1 and 6), you can run:
-- `tvae --name 'tvae_Lpartial_mnist_generalization'`
+- `tvae --name tvae_Lpartial_mnist_generalization`
 
 To rerun the experiments from Figures 22 and 23 (training on complex combined transformations), you can run:
-- `tvae --name 'tvae_Lpartial_perspective_mnist'`
-- `tvae --name 'tvae_Lpartial_rotcolor_mnist'`
+- `tvae --name tvae_Lpartial_perspective_mnist`
+- `tvae --name tvae_Lpartial_rotcolor_mnist`
 
 ## Basics of the framework
 - All models are built using the `TVAE` module (see `tvae/containers/tvae.py`) which requires a z-encoder, a u-encoder, a decoder, and a 'grouper'. The grouper module defines the topographic structure of the latent space through a `model` (equivalent to W in the paper), and a `padder` which defines the boundary conditions.

--- a/tvae/utils/train_loops.py
+++ b/tvae/utils/train_loops.py
@@ -49,7 +49,7 @@ def train_epoch(model, optimizer, train_loader, log, savepath, epoch, eval_batch
                 model.plot_decoder_weights(wandb_on=wandb_on)
                 model.plot_encoder_weights(wandb_on=wandb_on)
 
-            Plot_Covariance_Matrix(s**2.0, s**2.0, name='Covariance_S**2_batch', wandb_on=wandb_on)
+            Plot_Covariance_Matrix(s**2.0, s**2.0, name='Covariance_Sxx2_batch', wandb_on=wandb_on)
 
             if plot_fullcaptrav:
                 model.plot_capsule_traversal(x_batched.detach(), 
@@ -122,7 +122,7 @@ def eval_epoch(model, val_loader, log, savepath, epoch, n_is_samples=100,
         all_labels = torch.cat(all_labels, 0)
     if plot_cov:
         Plot_Covariance_Matrix(all_s, all_s, name='Covariance_S_Full', wandb_on=wandb_on)
-        Plot_Covariance_Matrix(all_s**2.0, all_s**2.0, name='Covariance_S**2_Full', wandb_on=wandb_on)
+        Plot_Covariance_Matrix(all_s**2.0, all_s**2.0, name='Covariance_Sxx2_Full', wandb_on=wandb_on)
     if plot_maxact:
         Plot_MaxActImg(all_s, all_x, os.path.join(savepath, 'samples'), epoch, wandb_on=wandb_on)
     if plot_class_selectivity:
@@ -184,7 +184,7 @@ def train_epoch_dsprites(model, optimizer, train_loader, log, savepath, epoch, e
                 model.plot_decoder_weights(wandb_on=wandb_on)
                 model.plot_encoder_weights(wandb_on=wandb_on)
 
-            Plot_Covariance_Matrix(s**2.0, s**2.0, name='Covariance_S**2_batch', wandb_on=wandb_on)
+            Plot_Covariance_Matrix(s**2.0, s**2.0, name='Covariance_Sxx2_batch', wandb_on=wandb_on)
 
             if plot_fullcaptrav:
                 model.plot_capsule_traversal(x_batched.detach(), 


### PR DESCRIPTION
When running tvae --name tvae_Lpartial_dsprites I got an error due to asterisk not being a valid file name character. 
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'C:\\Users\\admin\\AppData\\Local\\Temp\\2\\tmp04_mzg52wandb-media\\2n3e0t4i.png' -> 'c:\\data\\topographicvae-master\\tvae\\utils\\wandb\\run-20210921_085842-9scmcop8\\files\\media\\images\\Covariance_S**2_batch_5_b05a7d100c7773fd09bf.png'

The readme had extra apostrophe's.